### PR TITLE
Double quote csv values

### DIFF
--- a/src/main/java/com/github/lottetreg/matcha/CsvDatabase.java
+++ b/src/main/java/com/github/lottetreg/matcha/CsvDatabase.java
@@ -19,12 +19,13 @@ class CsvDatabase implements Persistable {
 
       ArrayList<String> recordValues = new ArrayList<>();
       headerMap.forEach((header, i) -> {
-        String value = data.get(header).toString();
+        String value = "\"" + data.get(header).toString() + "\"";
         recordValues.add(i, value);
       });
 
       FileWriter csvWriter = new FileWriter(csvName, true);
-      csvWriter.append(String.join(",", recordValues));
+      String value = String.join(",", recordValues);
+      csvWriter.append(value);
       csvWriter.append("\n");
       csvWriter.flush();
       csvWriter.close();

--- a/src/main/java/com/github/lottetreg/matcha/Template.java
+++ b/src/main/java/com/github/lottetreg/matcha/Template.java
@@ -2,6 +2,8 @@ package com.github.lottetreg.matcha;
 
 import org.jtwig.JtwigModel;
 import org.jtwig.JtwigTemplate;
+import org.jtwig.environment.EnvironmentConfiguration;
+import org.jtwig.environment.EnvironmentConfigurationBuilder;
 
 import java.util.Map;
 
@@ -13,7 +15,7 @@ public class Template {
   }
 
   byte[] render(Map<String, Object> context) {
-    JtwigTemplate template = JtwigTemplate.classpathTemplate(this.path);
+    JtwigTemplate template = JtwigTemplate.classpathTemplate(this.path, jtwigConfig());
     JtwigModel model = JtwigModel.newModel();
 
     context.forEach(model::with);
@@ -23,5 +25,14 @@ public class Template {
 
   String getPath() {
     return this.path;
+  }
+
+  private EnvironmentConfiguration jtwigConfig() {
+    return EnvironmentConfigurationBuilder
+        .configuration()
+          .escape()
+            .withInitialEngine("js")
+          .and()
+        .build();
   }
 }

--- a/src/test/java/com/github/lottetreg/matcha/CsvDatabaseTest.java
+++ b/src/test/java/com/github/lottetreg/matcha/CsvDatabaseTest.java
@@ -1,11 +1,12 @@
 package com.github.lottetreg.matcha;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -21,23 +22,45 @@ public class CsvDatabaseTest {
 
   private static Path postsTable = Path.of("posts.csv");
 
-  @BeforeClass
-  public static void setUpPostsTable() throws IOException {
+  @Before
+  public void setUpPostsTable() throws IOException {
     Files.createFile(postsTable);
     List<String> lines = new ArrayList<>();
     lines.add("slug,title,body");
-    lines.add("how-to-do-something,How to Do Something,Have you ever wanted to know how to do something?");
-    lines.add("how-to-do-something-else,How to Do Something Else,Have you ever wanted to know how to do something else?");
     Files.write(postsTable, lines);
   }
 
-  @AfterClass
-  public static void tearDownPostsTable() throws IOException {
+  @After
+  public void tearDownPostsTable() throws IOException {
     Files.delete(postsTable);
+  }
+
+  private void addLinesToPosts(List<String> lines) {
+    try {
+      FileWriter csvWriter = new FileWriter(postsTable.toString(), true);
+
+      lines.forEach((line) -> {
+        try {
+          csvWriter.append(line);
+          csvWriter.append("\n");
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      });
+
+      csvWriter.flush();
+      csvWriter.close();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Test
   public void itReturnsAListOfAllRecordsFromACSV() {
+    List<String> lines = new ArrayList<>();
+    lines.add("how-to-do-something,How to Do Something,Have you ever wanted to know how to do something?");
+    lines.add("how-to-do-something-else,How to Do Something Else,Have you ever wanted to know how to do something else?");
+    addLinesToPosts(lines);
     CsvDatabase database = new CsvDatabase();
 
     List<Map<String, String>> records = database.select("posts");
@@ -52,6 +75,9 @@ public class CsvDatabaseTest {
 
   @Test
   public void itReturnsARecordWithMatchingCriteriaFromACSV() {
+    List<String> lines = new ArrayList<>();
+    lines.add("how-to-do-something-else,How to Do Something Else,Have you ever wanted to know how to do something else?");
+    addLinesToPosts(lines);
     CsvDatabase database = new CsvDatabase();
 
     Map<String, String> record = database.select("posts", "slug", "how-to-do-something-else");
@@ -62,7 +88,7 @@ public class CsvDatabaseTest {
   }
 
   @Test
-  public void itInsertsANewRecordInACSV() {
+  public void itInsertsANewRecordInACSV() throws IOException {
     CsvDatabase database = new CsvDatabase();
     Map<String, Object> data = Map.of(
         "slug", "how-to-do-another-thing",
@@ -72,10 +98,8 @@ public class CsvDatabaseTest {
 
     database.insert("posts", data);
 
-    Map<String, String> createdRecord = database.select("posts", "slug", "how-to-do-another-thing");
-    assertEquals("how-to-do-another-thing", createdRecord.get("slug"));
-    assertEquals("How to Do Another Thing", createdRecord.get("title"));
-    assertEquals("Have you ever tried to do another thing?", createdRecord.get("body"));
+    byte[] fileContent = Files.readAllBytes(postsTable);
+    assertEquals("slug,title,body\n\"how-to-do-another-thing\",\"How to Do Another Thing\",\"Have you ever tried to do another thing?\"\n", new String(fileContent));
   }
 
   @Test


### PR DESCRIPTION
- Need to use double quotes in CSV in order to ignore commas in values
- Having Jtwig escape JS by default means Matcha users have to use `escape(false)` with `concat` which is a bit of a pain:

```
        {% for post in posts %}
          <a href={{ concat("/posts/", post.slug) | escape(false) }}><h3>{{ post.title }}</h3></a>
        {% endfor %}
```